### PR TITLE
[fix][gatsby-config] Fix Google Analytics tracking

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,6 +12,14 @@ module.exports = {
   },
   plugins: [
     {
+      resolve: "gatsby-plugin-google-analytics",
+      options: {
+        trackingId: "UA-57608712-2",
+        head: true,
+        anonymize: true,
+      },
+    },
+    {
       resolve: "gatsby-theme-mdx-deck",
       options: {
         // enable or disable gatsby-plugin-mdx
@@ -43,12 +51,7 @@ module.exports = {
     },
     "@pauliescanlon/gatsby-mdx-embed",
     "gatsby-plugin-sitemap",
-    {
-      resolve: "gatsby-plugin-google-analytics",
-      trackingId: "UA-57608712-2",
-      head: true,
-      anonymize: true,
-    },
+
     {
       resolve: "gatsby-plugin-manifest",
       options: {
@@ -117,4 +120,4 @@ module.exports = {
       },
     },
   ],
-};
+}


### PR DESCRIPTION
**Why this change was necessary**
Google Analytics was not activating because the plugin import was
incorrectly formatted.

**What this change does**
Moves the Google Analytics Gatsby plugin to the beginning of the
plugin list to ensure it's loaded first. Additionally, the plugin is
formatted correctly to include an `options` field enclosing the
available options.

**Additional context/notes/links**

https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics